### PR TITLE
Fixed email sender address

### DIFF
--- a/APSIM.Registration.Portal/Main.aspx.cs
+++ b/APSIM.Registration.Portal/Main.aspx.cs
@@ -164,7 +164,7 @@ namespace ProductRegistration
             try
             {
                 System.Net.Mail.MailMessage Mail = new System.Net.Mail.MailMessage();
-                Mail.From = new System.Net.Mail.MailAddress("no-reply@apsim.info");
+                Mail.From = new System.Net.Mail.MailAddress("no-reply@www.apsim.info");
                 Mail.To.Add(Email.Text);
                 Mail.Subject = "APSIM Software Non-Commercial Licence";
                 Mail.IsBodyHtml = true;


### PR DESCRIPTION
I've authenticated www.apsim.info domain with our sendgrid account to hopefully decrease the number of emails being blocked by mail servers. As part of this, we need to send from the www.apsim.info domain.