### PR TITLE
Disabled sendgrid link tracking to fix email links.

### DIFF
--- a/APSIM.Registration.Portal/EmailBody.html
+++ b/APSIM.Registration.Portal/EmailBody.html
@@ -8,7 +8,7 @@ APSIM Community Source Framework.</p>
 <p>Installation of the software indicates your acceptance of the terms and conditions attached. 
 If you do not agree to these terms and conditions <b>do not</b> proceed with the installation process.</p>
 
-<p>You can download APSIM <a href="$DownloadURL$">by clicking here.</a></p>
+<p>You can download APSIM <a clicktracking=off href="$DownloadURL$">by clicking here.</a></p>
 
 $MSI$
 


### PR DESCRIPTION
Without this fix, the download links in the emails will give a security error when clicked