### PR TITLE
Map NonCommercial stored value to Special Use enum value

### DIFF
--- a/source/Models/LicenceType.cs
+++ b/source/Models/LicenceType.cs
@@ -5,9 +5,12 @@ namespace APSIM.Registration.Models
     public enum LicenceType
     {
         [Display(Name = "General Use")]
-        GeneralUse,
+        GeneralUse = 0,
 
         [Display(Name = "Special Use")]
-        SpecialUse
+        SpecialUse = 1,
+        NonCommercial = 1
+
+
     }
 }


### PR DESCRIPTION
resolves #47

Just adds a NonCommercial alias to the Special Use LicenceType enum value to allow proper object mapping.