### PR TITLE
Change SMTP relay provider back to SendGrid

### DIFF
--- a/source/APSIM.Registration.csproj
+++ b/source/APSIM.Registration.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="ISO3166" Version="1.0.4" />
     <EmbeddedResource Include="Resources\**" />
-    <PackageReference Include="Mailjet.Api" Version="3.0.0" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
   </ItemGroup>
 

--- a/source/Pages/IndexModel.cshtml.cs
+++ b/source/Pages/IndexModel.cshtml.cs
@@ -474,8 +474,15 @@ namespace APSIM.Registration.Pages
                 msg.AddBcc(new EmailAddress(bccEmailAddress));
                 msg.AddBcc(new EmailAddress(apsimEmail));
                 var response = await client.SendEmailAsync(msg);
-
-                logger.LogInformation($"Sent invoice email to {RegistrationDetails.Email}, {bccEmailAddress}, and {apsimEmail}");
+                if (response.StatusCode != System.Net.HttpStatusCode.Accepted &&
+                    response.StatusCode != System.Net.HttpStatusCode.OK)
+                {
+                    logger.LogWarning($"Failed to send invoice email. Status code: {response.StatusCode}");
+                }
+                else
+                {
+                    logger.LogInformation($"Sent invoice email to {RegistrationDetails.Email}, {bccEmailAddress}, and {apsimEmail}");
+                }
             }
             catch (Exception e)
             {
@@ -498,7 +505,15 @@ namespace APSIM.Registration.Pages
                 var msg = MailHelper.CreateSingleEmail(from, to, subject, "", htmlContent);
                 msg.AddBcc(new EmailAddress(bccEmailAddress));
                 var response = await client.SendEmailAsync(msg);
-                logger.LogInformation($"Sent registration email to {RegistrationDetails.Email}");
+                if (response.StatusCode != System.Net.HttpStatusCode.Accepted &&
+                    response.StatusCode != System.Net.HttpStatusCode.OK)
+                {
+                    logger.LogWarning($"Failed to send registration email. Status code: {response.StatusCode}");
+                }
+                else
+                {
+                    logger.LogInformation($"Sent registration email to {RegistrationDetails.Email}");
+                }
             }
             catch (Exception error)
             {


### PR DESCRIPTION
resolves #68

Uses the SendGrid API rather than MailJet API for all sending of invoice and registration emails.